### PR TITLE
Add ART Containerfile for build test

### DIFF
--- a/Containerfile.art
+++ b/Containerfile.art
@@ -1,0 +1,54 @@
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.25 AS builder
+ARG SOURCE_DIR="/go/src/github.com/openshift/external-secrets-bitwarden-sdk-server"
+
+WORKDIR $SOURCE_DIR
+# ART builds from source repos without git submodules
+COPY . .
+COPY LICENSE /licenses/
+
+ENV GO_BUILD_TAGS=strictfipsruntime,openssl
+ENV GOEXPERIMENT=strictfipsruntime
+ENV CGO_ENABLED=1
+ENV GOFLAGS=""
+ENV OPENSHIFT_CI=1
+
+RUN mkdir state && CGO_LDFLAGS="-lm" go build -a -ldflags '-linkmode external -extldflags "-static -Wl,-unresolved-symbols=ignore-all"' -tags ${GO_BUILD_TAGS} -o bin/bitwarden-sdk-server main.go
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:83006d535923fcf1345067873524a3980316f51794f01d8655be55d6e9387183
+
+# Values for below ARGs will passed from tekton configs for konflux builds.
+## Release version of the external-secrets-bitwarden-sdk-server source code used in the build.
+ARG RELEASE_VERSION
+## Commit hash that considered for the image build.
+ARG COMMIT_SHA
+## github URL of the external-secrets-bitwarden-sdk-server source repository.
+ARG SOURCE_URL
+ARG SOURCE_DIR="/go/src/github.com/openshift/external-secrets-bitwarden-sdk-server"
+
+COPY --from=builder $SOURCE_DIR/bin/bitwarden-sdk-server /bin/bitwarden-sdk-server
+COPY --from=builder --chown=65534:65534 $SOURCE_DIR/state /state
+COPY --from=builder /licenses /licenses
+
+EXPOSE 9998
+ENV CGO_ENABLED=1
+ENV BW_SECRETS_MANAGER_STATE_PATH='/state'
+USER 65534:65534
+
+LABEL com.redhat.component="external-secrets-bitwarden-sdk-server-container" \
+      cpe="cpe:/a:redhat:external_secrets_operator:1.1::el9" \
+      name="external-secrets-operator/bitwarden-sdk-server-rhel9" \
+      version="${RELEASE_VERSION}" \
+      summary="external-secrets-bitwarden-sdk-server" \
+      maintainer="Red Hat, Inc." \
+      description="external-secrets-bitwarden-sdk-server-container" \
+      vendor="Red Hat, Inc." \
+      release="${RELEASE_VERSION}" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="data,images,external-secrets,external-secrets-operator" \
+      io.openshift.build.commit.id="${COMMIT_SHA}" \
+      io.openshift.build.source-location="${SOURCE_URL}" \
+      io.openshift.build.commit.url="${SOURCE_URL}/commit/${COMMIT_SHA}" \
+      io.k8s.display-name="external-secrets-bitwarden-sdk-server" \
+      io.k8s.description="external-secrets-bitwarden-sdk-server-container"
+
+ENTRYPOINT [ "/bin/bitwarden-sdk-server", "serve" ]


### PR DESCRIPTION
Signed-off-by: Franco Bladilo <fbladilo@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

## Problem Statement

ART needs to build external-secrets-bitwarden-sdk-server images through its Konflux-based layered products pipeline. ART builds require a dedicated Containerfile.art with ART's builder images, base images, and LABEL conventions.

## Related Issue

Part of [ART-14816](https://redhat.atlassian.net/browse/ART-14816) (Onboard OAP operators to ART) and [ART-14821](https://redhat.atlassian.net/browse/ART-14821) (Onboard External Secrets Operator to ocp-build-data).

## Proposed Changes

Add Containerfile.art to the release-0.5.2 branch. This Containerfile uses ART's golang builder, ubi9/ubi-minimal as runtime base, and includes required Red Hat container LABELs. It exists alongside the existing Dockerfile without modifying it.

## Checklist

- [x] I have read the [contribution
guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`